### PR TITLE
Updated RestClient to use :params

### DIFF
--- a/lib/delayed_jobs/process_new_articles_job.rb
+++ b/lib/delayed_jobs/process_new_articles_job.rb
@@ -93,9 +93,9 @@ class ProcessNewArticlesJob < Struct.new(:rss_feed, :settings)
     request_type = rss_feed['type']
     begin
       if request_type && request_type == 'get'
-        RestClient.get webhook, output_hash
+        RestClient.get webhook, :params => output_hash
       else
-        RestClient.post webhook, output_hash
+        RestClient.post webhook, :params => output_hash
       end
     rescue => e
       e.response


### PR DESCRIPTION
RestClient requires `:params => output_hash` before it will actually send the output_hash with the request.
